### PR TITLE
Added some bean overrides for native compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,24 @@
             <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-autoconfigure</artifactId>
+            <version>${axon.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>${spring-boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.1.214</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Database -->
         <dependency>
             <groupId>jakarta.persistence</groupId>

--- a/src/main/java/org/axonframework/springboot/aot/autoconfig/ResourceInjectorAutoConfiguration.java
+++ b/src/main/java/org/axonframework/springboot/aot/autoconfig/ResourceInjectorAutoConfiguration.java
@@ -1,0 +1,20 @@
+package org.axonframework.springboot.aot.autoconfig;
+
+import org.axonframework.config.Configuration;
+import org.axonframework.config.ConfigurationResourceInjector;
+import org.axonframework.modelling.saga.ResourceInjector;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration(beforeName = "org.axonframework.springboot.autoconfig.InfraConfiguration")
+@ConditionalOnClass({ResourceInjector.class, Configuration.class})
+public class ResourceInjectorAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ResourceInjector resourceInjector(Configuration axonConfig) {
+        return new ConfigurationResourceInjector(axonConfig);
+    }
+}

--- a/src/main/java/org/axonframework/springboot/aot/autoconfig/ResourceInjectorAutoConfiguration.java
+++ b/src/main/java/org/axonframework/springboot/aot/autoconfig/ResourceInjectorAutoConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.springboot.aot.autoconfig;
 
 import org.axonframework.config.Configuration;
@@ -8,6 +24,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
+/**
+ * Autoconfiguration class that configures the ConfigurationResourceInjector rather than the framework-provided
+ * {@link org.axonframework.spring.saga.SpringResourceInjector}. In native-compiled applications, the logic used by the
+ * SpringResourceInjector isn't available.
+ *
+ * @author Allard Buijze
+ */
 @AutoConfiguration(beforeName = "org.axonframework.springboot.autoconfig.InfraConfiguration")
 @ConditionalOnClass({ResourceInjector.class, Configuration.class})
 public class ResourceInjectorAutoConfiguration {

--- a/src/main/java/org/axonframework/springboot/aot/autoconfig/SimpleEntityManagerProviderAutoConfiguration.java
+++ b/src/main/java/org/axonframework/springboot/aot/autoconfig/SimpleEntityManagerProviderAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -39,6 +40,7 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnBean(EntityManagerFactory.class)
 public class SimpleEntityManagerProviderAutoConfiguration {
 
+    @ConditionalOnMissingBean
     @Bean
     public EntityManagerProvider entityManagerProvider(EntityManager entityManager) {
         return new SimpleEntityManagerProvider(entityManager);

--- a/src/main/java/org/axonframework/springboot/aot/autoconfig/SimpleEntityManagerProviderAutoConfiguration.java
+++ b/src/main/java/org/axonframework/springboot/aot/autoconfig/SimpleEntityManagerProviderAutoConfiguration.java
@@ -17,9 +17,11 @@
 package org.axonframework.springboot.aot.autoconfig;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.common.jpa.SimpleEntityManagerProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
@@ -33,7 +35,8 @@ import org.springframework.context.annotation.Bean;
  */
 @AutoConfiguration
 @AutoConfigureBefore(name = "org.axonframework.springboot.autoconfig.JpaAutoConfiguration")
-@ConditionalOnBean(EntityManager.class)
+@AutoConfigureAfter(name = "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration")
+@ConditionalOnBean(EntityManagerFactory.class)
 public class SimpleEntityManagerProviderAutoConfiguration {
 
     @Bean

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 org.axonframework.springboot.aot.autoconfig.DefaultTargetContextResolverAutoConfiguration
 org.axonframework.springboot.aot.autoconfig.SimpleEntityManagerProviderAutoConfiguration
+org.axonframework.springboot.aot.autoconfig.ResourceInjectorAutoConfiguration

--- a/src/test/java/org/axonframework/springboot/aot/autoconfig/DefaultTargetContextResolverAutoConfigurationTest.java
+++ b/src/test/java/org/axonframework/springboot/aot/autoconfig/DefaultTargetContextResolverAutoConfigurationTest.java
@@ -35,6 +35,7 @@ class DefaultTargetContextResolverAutoConfigurationTest {
     void defaultContextResolverIsPresent() {
         new ApplicationContextRunner()
                 .withUserConfiguration(TestContext.class)
+                .withPropertyValues("axon.axonserver.enabled=false")
                 .run(context -> {
                     TargetContextResolver<?> resolver = context.getBean(TargetContextResolver.class);
                     assertNotNull(resolver);

--- a/src/test/java/org/axonframework/springboot/aot/autoconfig/ResourceInjectorAutoConfigurationTest.java
+++ b/src/test/java/org/axonframework/springboot/aot/autoconfig/ResourceInjectorAutoConfigurationTest.java
@@ -16,37 +16,25 @@
 
 package org.axonframework.springboot.aot.autoconfig;
 
-import jakarta.persistence.EntityManager;
-import org.axonframework.common.jpa.EntityManagerProvider;
-import org.axonframework.common.jpa.SimpleEntityManagerProvider;
 import org.axonframework.config.ConfigurationResourceInjector;
 import org.axonframework.modelling.saga.ResourceInjector;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
-/**
- * Tests the {@link SimpleEntityManagerProviderAutoConfiguration} providing a {@link SimpleEntityManagerProvider}.
- *
- * @author Gerard Klijs
- */
 class ResourceInjectorAutoConfigurationTest {
 
     @Test
-    void defaultContextResolverIsPresent() {
-        new ApplicationContextRunner()
-                .withUserConfiguration(TestContext.class)
-                .withPropertyValues("axon.axonserver.enabled=false")
-                .run(context -> {
-                    ResourceInjector resourceInjector = context.getBean(ResourceInjector.class);
-                    assertNotNull(resourceInjector);
-                    assertTrue(resourceInjector instanceof ConfigurationResourceInjector);
-                });
+    void defaultResourceInjectorIsPresent() {
+        new ApplicationContextRunner().withUserConfiguration(TestContext.class).withPropertyValues(
+                "axon.axonserver.enabled=false").run(context -> {
+            ResourceInjector resourceInjector = context.getBean(ResourceInjector.class);
+            assertNotNull(resourceInjector);
+            assertTrue(resourceInjector instanceof ConfigurationResourceInjector);
+        });
     }
 
 

--- a/src/test/java/org/axonframework/springboot/aot/autoconfig/ResourceInjectorAutoConfigurationTest.java
+++ b/src/test/java/org/axonframework/springboot/aot/autoconfig/ResourceInjectorAutoConfigurationTest.java
@@ -19,11 +19,12 @@ package org.axonframework.springboot.aot.autoconfig;
 import jakarta.persistence.EntityManager;
 import org.axonframework.common.jpa.EntityManagerProvider;
 import org.axonframework.common.jpa.SimpleEntityManagerProvider;
+import org.axonframework.config.ConfigurationResourceInjector;
+import org.axonframework.modelling.saga.ResourceInjector;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Gerard Klijs
  */
-class SimpleEntityManagerProviderAutoConfigurationTest {
+class ResourceInjectorAutoConfigurationTest {
 
     @Test
     void defaultContextResolverIsPresent() {
@@ -42,9 +43,9 @@ class SimpleEntityManagerProviderAutoConfigurationTest {
                 .withUserConfiguration(TestContext.class)
                 .withPropertyValues("axon.axonserver.enabled=false")
                 .run(context -> {
-                    EntityManagerProvider entityManagerProvider = context.getBean(EntityManagerProvider.class);
-                    assertNotNull(entityManagerProvider);
-                    assertTrue(entityManagerProvider instanceof SimpleEntityManagerProvider);
+                    ResourceInjector resourceInjector = context.getBean(ResourceInjector.class);
+                    assertNotNull(resourceInjector);
+                    assertTrue(resourceInjector instanceof ConfigurationResourceInjector);
                 });
     }
 
@@ -52,7 +53,6 @@ class SimpleEntityManagerProviderAutoConfigurationTest {
     @ContextConfiguration
     @EnableAutoConfiguration
     private static class TestContext {
-
 
     }
 }

--- a/src/test/java/org/axonframework/springboot/aot/autoconfig/SimpleEntityManagerProviderAutoConfigurationTest.java
+++ b/src/test/java/org/axonframework/springboot/aot/autoconfig/SimpleEntityManagerProviderAutoConfigurationTest.java
@@ -50,23 +50,22 @@ class SimpleEntityManagerProviderAutoConfigurationTest {
     @Test
     void customSimpleEntityManagerIsConfigured() {
         new ApplicationContextRunner()
-                .withUserConfiguration(CustomerEntityManagerContext.class)
+                .withUserConfiguration(CustomEntityManagerContext.class)
                 .withPropertyValues("axon.axonserver.enabled=false")
                 .run(context -> {
                     EntityManagerProvider entityManagerProvider = context.getBean(EntityManagerProvider.class);
                     assertNotNull(entityManagerProvider);
-                    assertTrue(entityManagerProvider instanceof CustomerEntityManagerContext.CustomEntityManagerProvider);
+                    assertTrue(entityManagerProvider instanceof CustomEntityManagerContext.CustomEntityManagerProvider);
                 });
     }
 
-    @ContextConfiguration
     @EnableAutoConfiguration
     private static class EmptyTestContext {
 
     }
 
-    @Configuration
-    private static class CustomerEntityManagerContext {
+    @EnableAutoConfiguration
+    private static class CustomEntityManagerContext {
 
         @Bean
         EntityManagerProvider customEntityManagerProvider() {

--- a/src/test/java/org/axonframework/springboot/aot/autoconfig/SimpleEntityManagerProviderAutoConfigurationTest.java
+++ b/src/test/java/org/axonframework/springboot/aot/autoconfig/SimpleEntityManagerProviderAutoConfigurationTest.java
@@ -27,7 +27,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Tests the {@link SimpleEntityManagerProviderAutoConfiguration} providing a {@link SimpleEntityManagerProvider}.
@@ -37,9 +36,9 @@ import static org.mockito.Mockito.*;
 class SimpleEntityManagerProviderAutoConfigurationTest {
 
     @Test
-    void defaultContextResolverIsPresent() {
+    void defaultSimpleEntityManagerIsConfigured() {
         new ApplicationContextRunner()
-                .withUserConfiguration(TestContext.class)
+                .withUserConfiguration(EmptyTestContext.class)
                 .withPropertyValues("axon.axonserver.enabled=false")
                 .run(context -> {
                     EntityManagerProvider entityManagerProvider = context.getBean(EntityManagerProvider.class);
@@ -48,11 +47,38 @@ class SimpleEntityManagerProviderAutoConfigurationTest {
                 });
     }
 
+    @Test
+    void customSimpleEntityManagerIsConfigured() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(CustomerEntityManagerContext.class)
+                .withPropertyValues("axon.axonserver.enabled=false")
+                .run(context -> {
+                    EntityManagerProvider entityManagerProvider = context.getBean(EntityManagerProvider.class);
+                    assertNotNull(entityManagerProvider);
+                    assertTrue(entityManagerProvider instanceof CustomerEntityManagerContext.CustomEntityManagerProvider);
+                });
+    }
 
     @ContextConfiguration
     @EnableAutoConfiguration
-    private static class TestContext {
+    private static class EmptyTestContext {
+
+    }
+
+    @Configuration
+    private static class CustomerEntityManagerContext {
+
+        @Bean
+        EntityManagerProvider customEntityManagerProvider() {
+            return new CustomEntityManagerProvider();
+        }
 
 
+        private static class CustomEntityManagerProvider implements EntityManagerProvider {
+            @Override
+            public EntityManager getEntityManager() {
+                return null;
+            }
+        }
     }
 }


### PR DESCRIPTION
Some default beans aren't compatible with Spring AOT when compiled to native. The resourceInjector now defaults to the ConfigurationResourceInjector, as it will also automatically consider Spring Beans as resources.