### PR TITLE
Fix to both fix the test, and the actual code.

### DIFF
--- a/src/main/java/org/axonframework/springboot/aot/AxonRuntimeHints.java
+++ b/src/main/java/org/axonframework/springboot/aot/AxonRuntimeHints.java
@@ -69,7 +69,7 @@ public class AxonRuntimeHints implements RuntimeHintsRegistrar {
     private void registerGrpcHints(ReflectionHints hints) {
         hints.registerType(
                 TypeReference.of("io.netty.channel.epoll.EpollChannelOption"),
-                MemberCategory.DECLARED_FIELDS);
+                MemberCategory.PUBLIC_FIELDS);
     }
 
     private Type[] axonSerializableClasses() {


### PR DESCRIPTION
Verified with a gift card project running with Axon Framework 4.9.0-SNAPSHOT.
I don't know why the change is needed. The `EpollChannelOption` class doesn't seem to have changed, so likely how Spring works with the registered hints has changed somehow.