### PR TITLE
Move old docs 2 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ For more information on anything Axon, please visit our website, [http://axoniq.
 
 ## Getting started
 
-The [reference guide](https://docs.axoniq.io) contains a separate chapter for all the extensions.
-The Spring Native extension description can be
-found [here](https://docs.axoniq.io/reference-guide/extensions/spring-aot).
+The [AxonIQ Library](https://library.axoniq.io) contains a section for the guides of all the Axon Framework extensions.
+The Spring AOT extension guide can be found [here](https://library.axoniq.io/home/guides/axon-framework.html).
 
 ## Receiving help
 
@@ -33,11 +32,10 @@ Are you having trouble using the extension?
 We'd like to help you out the best we can!
 There are a couple of things to consider when you're traversing anything Axon:
 
-* Checking the [reference guide](https://docs.axoniq.io/reference-guide/extensions/spring-aot) should be your first
-  stop,
+* Checking the [reference guide](https://library.axoniq.io/axon_framework_old_ref/) should be your first stop,
   as the majority of possible scenarios you might encounter when using Axon should be covered there.
 * If the Reference Guide does not cover a specific topic you would've expected,
-  we'd appreciate if you could file an [issue](https://github.com/AxonIQ/reference-guide/issues) about it for us.
+  we'd appreciate if you could post a [new thread/topic on our library fourms describing the problem](https://discuss.axoniq.io/c/26).
 * There is a [forum](https://discuss.axoniq.io/) to support you in the case the reference guide did not sufficiently answer your question.
   Axon Framework and Server developers will help out on a best effort basis.
   Know that any support from contributors on posted question is very much appreciated on the forum.

--- a/docs/_playbook/.gitignore
+++ b/docs/_playbook/.gitignore
@@ -1,0 +1,5 @@
+build
+node_modules
+.vscode
+vale
+package-lock.json

--- a/docs/_playbook/.vale.ini
+++ b/docs/_playbook/.vale.ini
@@ -1,0 +1,23 @@
+StylesPath = vale
+
+MinAlertLevel = suggestion
+
+Packages = http://github.com/AxonIQ/axoniq-vale-package/releases/latest/download/axoniq-vale-package.zip
+
+Vocab = general, AxonIQ, Java, Names_Terms, misc
+
+[*.{adoc,html}]
+BasedOnStyles = AxonIQ, proselint, Google
+
+Google.Headings = NO # Diasable in favor od AxonIQ one
+Google.Parens = NO # Disable warning about using parens
+Google.Quotes = NO # Diasable "commas and periods go inside quotation marks"
+Google.WordList = NO # Disable Google's word list
+Google.Passive = NO # Allow the use of Passive voice
+Google.Colons = NO # Allow the use of Colons
+Google.Will = NO # Allow use will
+Google.Contractions = NO
+Google.We = NO
+
+
+

--- a/docs/_playbook/package.json
+++ b/docs/_playbook/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "@antora/atlas-extension": "^1.0.0-alpha.2",
+    "@antora/cli": "^3.2.0-alpha.2",
+    "@antora/lunr-extension": "^1.0.0-alpha.8",
+    "@antora/site-generator": "^3.2.0-alpha.2",
+    "@asciidoctor/tabs": "^1.0.0-beta.6",
+    "@axoniq/antora-vale-extension": "^0.1.1",
+    "asciidoctor-kroki": "^0.17.0"
+  }
+}

--- a/docs/_playbook/playbook.yaml
+++ b/docs/_playbook/playbook.yaml
@@ -1,0 +1,42 @@
+site:
+  title: Spring AOT Extension docs PREVIEW
+  start_page: springaot_extension_guide::index.adoc
+
+content:
+  sources:
+  - url: ../..
+    start_paths: ['docs/*', '!docs/_*']
+
+asciidoc:
+  attributes:
+    experimental: true
+    page-pagination: true
+    kroki-fetch-diagram: true
+  #   primary-site-manifest-url: https://library.axoniq.io/site-manifest.json
+  extensions:
+    - asciidoctor-kroki
+    - '@asciidoctor/tabs'
+
+antora:
+  extensions:
+    - id: prose-linting
+      require: '@axoniq/antora-vale-extension'
+      enabled: true
+      vale_config: .vale.ini
+      update_styles: true
+    - id: lunr
+      require: '@antora/lunr-extension'
+      enabled: true
+      index_latest_only: true
+    - id: atlas
+      require: '@antora/atlas-extension'
+
+runtime:
+  fetch: true # fetch remote repos
+  log:
+    level: info
+    failure_level: error
+
+ui:
+  bundle:
+    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.0.1.10/ui-bundle.zip

--- a/docs/extension-guide/antora.yml
+++ b/docs/extension-guide/antora.yml
@@ -1,0 +1,14 @@
+name: springaot_extension_guide
+title: Spring AOT Extension Guide
+version: true
+prerelease: true
+start_page: ROOT:index.adoc
+
+asciidoc:
+  attributes:
+    component_description: The Spring AOT Extension guide from the former reference guide
+    type: guide
+    group: axon-framework
+
+nav:
+  - modules/nav.adoc

--- a/docs/extension-guide/modules/ROOT/pages/compile-to-native.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/compile-to-native.adoc
@@ -1,0 +1,17 @@
+:navtitle: Compiling to Native
+= Compiling to Native
+
+Before you set up this extension, it's important to read through the link:https://docs.spring.io/spring-boot/docs/current/reference/html/native-image.html[documentation,window=_blank,role=external] from Spring itself. There are some known limitations that might require additional changes to the application. In addition, this extension needs to be added by adding the following dependency:
+
+
+[sources,xml]
+----
+<dependency>
+<groupId>org.axonframework.extensions.spring-aot</groupId>
+<artifactId>axon-spring-aot</artifactId>
+<version>4.8.0</version>
+</dependency>
+----
+
+This should be enough to have additional hints with ahead of time compilation to successfully build and run your Axon application.
+

--- a/docs/extension-guide/modules/ROOT/pages/index.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/index.adoc
@@ -1,0 +1,8 @@
+:navtitle: Spring Ahead of Time
+= Spring Ahead of Time
+
+link:https://docs.spring.io/spring-boot/docs/current/reference/html/native-image.html#native-image.introducing-graalvm-native-images.understanding-aot-processing[Spring AOT processing,window=_blank,role=external] is part of the process to create a native binary from a Spring (Boot) application. This extension will help in adding a lot of hints which are needed for Axon Framework. Please note this extension can only be used with Spring Boot 3, as such it requires at least Java 17.
+
+Besides the extension, it might be necessary to make more changes to successfully compile and run an application as a native image. For example, when a message isn't used in a handler. This is quite common when the application is split, and the application sending certain messages is not the same as the application handling the messages. In those cases these messages need to be added to the link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/ImportRuntimeHints.html[`ImportRuntimeHints`,window=_blank,role=external] annotation. Otherwise, these messages can't be deserialized, leading to errors at runtime.
+
+If something is not working or only works with additional hints, and it's Axon-specific, please let us know either at link:https://github.com/AxonFramework/extension-spring-aot/issues[GitHub,window=_blank,role=external] or link:https://discuss.axoniq.io/c/axonframework/[Discuss,window=_blank,role=external].

--- a/docs/extension-guide/modules/ROOT/pages/performance.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/performance.adoc
@@ -1,0 +1,4 @@
+:navtitle: Performance Tips
+= Performance Tips
+
+It can be beneficial to move from JPA implementations to JDBC implementations. This likely decreases both the time it takes to compile the image and the time to start the image.

--- a/docs/extension-guide/modules/nav.adoc
+++ b/docs/extension-guide/modules/nav.adoc
@@ -1,0 +1,3 @@
+* xref::index.adoc[]
+** xref::compile-to-native.adoc[]
+** xref::performance.adoc[]


### PR DESCRIPTION
Moved doc contents from Extension section for Spring AOT in the old reference guide to here so that antora can publish the Spring AOT Extension Guide at library.axoniq.io under Guides > Axon Framework