### PR TITLE
Added native-compilation hints for reflection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,7 @@
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <!-- test -->

--- a/src/main/java/org/axonframework/springboot/aot/MessageHandlerRuntimeHintsRegistrar.java
+++ b/src/main/java/org/axonframework/springboot/aot/MessageHandlerRuntimeHintsRegistrar.java
@@ -16,9 +16,17 @@
 
 package org.axonframework.springboot.aot;
 
+import org.axonframework.common.Priority;
+import org.axonframework.common.ReflectionUtils;
+import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.annotation.AnnotatedHandlerInspector;
+import org.axonframework.messaging.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
+import org.axonframework.messaging.annotation.MultiParameterResolverFactory;
+import org.axonframework.messaging.annotation.ParameterResolver;
+import org.axonframework.messaging.annotation.ParameterResolverFactory;
+import org.axonframework.modelling.command.AggregateMember;
 import org.axonframework.queryhandling.annotation.QueryHandlingMember;
 import org.axonframework.spring.config.MessageHandlerLookup;
 import org.springframework.aot.generate.GenerationContext;
@@ -31,10 +39,17 @@ import org.springframework.beans.factory.aot.BeanFactoryInitializationCode;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * BeanFactoryInitializationAotProcessor that registers message handler methods declared on beans for reflection. This
@@ -50,19 +65,59 @@ public class MessageHandlerRuntimeHintsRegistrar implements BeanFactoryInitializ
 
     @Override
     public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
-        List<Class<?>> messageHandlingClasses =
+        Set<Class<?>> messageHandlingClasses =
                 MessageHandlerLookup.messageHandlerBeans(messageType(), beanFactory, true)
                                     .stream()
                                     .map(beanFactory::getType)
-                                    .distinct()
-                                    .collect(Collectors.toList());
-        List<MessageHandlingMember<?>> messageHandlingMembers = messageHandlingClasses
+                                    .collect(Collectors.toSet());
+
+        Set<Class<?>> detectedClasses = new HashSet<>();
+        messageHandlingClasses.forEach(c -> registerAggregateMembers(c, detectedClasses));
+
+        List<MessageHandlingMember<?>> messageHandlingMembers = detectedClasses
                 .stream()
-                .flatMap(beanType -> AnnotatedHandlerInspector.inspectType(beanType).getAllHandlers().values()
-                                                              .stream())
+                .flatMap(beanType ->
+                         {
+                             AnnotatedHandlerInspector<?> inspector = AnnotatedHandlerInspector.inspectType(
+                                     beanType,
+                                     MultiParameterResolverFactory.ordered(
+                                             ClasspathParameterResolverFactory.forClass(beanType),
+                                             new LenientParameterResolver()
+                                     ));
+                             return Stream.concat(inspector.getAllHandlers().values().stream(),
+                                                  inspector.getAllInterceptors().values().stream());
+                         })
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
-        return new MessageHandlerContribution(messageHandlingClasses, messageHandlingMembers);
+        return new MessageHandlerContribution(detectedClasses, messageHandlingMembers);
+    }
+
+    private void registerAggregateMembers(Class<?> entityType, Set<Class<?>> reflectiveClasses) {
+        if (!reflectiveClasses.add(entityType)) {
+            return;
+        }
+
+        ReflectionUtils.fieldsOf(entityType).forEach(field -> {
+            Optional<Map<String, Object>> annotationAttributes = AnnotationUtils.findAnnotationAttributes(field,
+                                                                                                          AggregateMember.class);
+            if (annotationAttributes.isPresent()) {
+                Class<?> declaredType = (Class<?>) annotationAttributes.get().get("type");
+                Class<?> forwardingMode = (Class<?>) annotationAttributes.get().get("eventForwardingMode");
+                reflectiveClasses.add(forwardingMode);
+
+                if (declaredType != Void.class) {
+                    registerAggregateMembers(declaredType, reflectiveClasses);
+                } else if (Map.class.isAssignableFrom(field.getType())) {
+                    Optional<Class<?>> type = ReflectionUtils.resolveMemberGenericType(field, 1);
+                    type.ifPresent(t -> registerAggregateMembers(t, reflectiveClasses));
+                } else if (Collection.class.isAssignableFrom(field.getType())) {
+                    Optional<Class<?>> type = ReflectionUtils.resolveMemberGenericType(field, 0);
+                    type.ifPresent(t -> registerAggregateMembers(t, reflectiveClasses));
+                } else {
+                    registerAggregateMembers(field.getType(), reflectiveClasses);
+                }
+            }
+        });
     }
 
     /**
@@ -80,14 +135,13 @@ public class MessageHandlerRuntimeHintsRegistrar implements BeanFactoryInitializ
 
         private final BindingReflectionHintsRegistrar registrar = new BindingReflectionHintsRegistrar();
 
-        private final List<Class<?>> messageHandlingClasses;
+        private final Set<Class<?>> messageHandlingClasses;
 
         private final List<MessageHandlingMember<?>> messageHandlingMembers;
 
         public MessageHandlerContribution(
-                List<Class<?>> messageHandlingClasses,
-                List<MessageHandlingMember<?>> messageHandlingMembers
-        ) {
+                Set<Class<?>> messageHandlingClasses,
+                List<MessageHandlingMember<?>> messageHandlingMembers) {
             this.messageHandlingClasses = messageHandlingClasses;
             this.messageHandlingMembers = messageHandlingMembers;
         }
@@ -106,6 +160,28 @@ public class MessageHandlerRuntimeHintsRegistrar implements BeanFactoryInitializ
                     registrar.registerReflectionHints(reflectionHints, queryHandlingMember.getResultType());
                 }
             });
+        }
+    }
+
+    @Priority(Priority.LAST)
+    private static class LenientParameterResolver implements ParameterResolverFactory, ParameterResolver<Object> {
+
+        @Override
+        public ParameterResolver<Object> createInstance(Executable executable,
+                                                        Parameter[] parameters,
+                                                        int parameterIndex) {
+            return this;
+        }
+
+        @Override
+        public Object resolveParameterValue(Message message) {
+            throw new UnsupportedOperationException(
+                    "This parameter resolver is not mean for production use. Only for detecting handler methods.");
+        }
+
+        @Override
+        public boolean matches(Message message) {
+            return true;
         }
     }
 }

--- a/src/test/java/com/axoniq/someproject/SomeBean.java
+++ b/src/test/java/com/axoniq/someproject/SomeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,6 @@
 
 package com.axoniq.someproject;
 
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-
-@SpringBootApplication
-public class App {
-
-    @Bean
-    public SomeBean springBean() {
-        return new SomeBean();
-    }
+public class SomeBean {
 
 }

--- a/src/test/java/com/axoniq/someproject/something/SingleAggregateChild.java
+++ b/src/test/java/com/axoniq/someproject/something/SingleAggregateChild.java
@@ -16,9 +16,11 @@
 
 package com.axoniq.someproject.something;
 
+import com.axoniq.someproject.SomeBean;
 import com.axoniq.someproject.api.SingleChildCommand;
-import com.axoniq.someproject.api.SomeChildCommand;
 import org.axonframework.commandhandling.CommandHandler;
+import org.axonframework.messaging.InterceptorChain;
+import org.axonframework.modelling.command.CommandHandlerInterceptor;
 import org.axonframework.modelling.command.EntityId;
 
 public record SingleAggregateChild(
@@ -26,8 +28,13 @@ public record SingleAggregateChild(
         String property
 ) {
 
+    @CommandHandlerInterceptor
+    public Object intercept(InterceptorChain chain) throws Exception {
+        return chain.proceed();
+    }
+
     @CommandHandler
-    public void handle(SingleChildCommand command) {
+    public void handle(SingleChildCommand command, SomeBean someBean) {
         //left empty to not overcomplicate things
     }
 }

--- a/src/test/java/com/axoniq/someproject/something/SomeAggregateChild.java
+++ b/src/test/java/com/axoniq/someproject/something/SomeAggregateChild.java
@@ -16,6 +16,7 @@
 
 package com.axoniq.someproject.something;
 
+import com.axoniq.someproject.SomeBean;
 import com.axoniq.someproject.api.SomeChildCommand;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.modelling.command.EntityId;
@@ -26,7 +27,7 @@ public record SomeAggregateChild(
 ) {
 
     @CommandHandler
-    public void handle(SomeChildCommand command) {
+    public void handle(SomeChildCommand command, SomeBean someBean) {
         //left empty to not overcomplicate things
     }
 }

--- a/src/test/java/org/axonframework/springboot/aot/MessageHandlerRuntimeHintsRegistrarTest.java
+++ b/src/test/java/org/axonframework/springboot/aot/MessageHandlerRuntimeHintsRegistrarTest.java
@@ -30,6 +30,8 @@ import com.axoniq.someproject.something.SomeAggregate;
 import com.axoniq.someproject.something.SomeAggregateChild;
 import com.axoniq.someproject.something.SomeProjectionWithGroupAnnotation;
 import com.axoniq.someproject.something.SomeProjectionWithoutGroupAnnotation;
+import org.axonframework.modelling.command.ForwardMatchingInstances;
+import org.axonframework.modelling.command.ForwardToAll;
 import org.junit.jupiter.api.*;
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 import org.springframework.aot.test.generate.TestGenerationContext;
@@ -51,8 +53,6 @@ class MessageHandlerRuntimeHintsRegistrarTest {
     @BeforeEach
     void processAheadOfTime() {
         addClassToBeanFactory(SomeAggregate.class);
-        addClassToBeanFactory(SingleAggregateChild.class);
-        addClassToBeanFactory(SomeAggregateChild.class);
         addClassToBeanFactory(SomeProjectionWithGroupAnnotation.class);
         addClassToBeanFactory(SomeProjectionWithoutGroupAnnotation.class);
         new ApplicationContextAotGenerator().processAheadOfTime(this.applicationContext, this.generationContext);
@@ -85,6 +85,22 @@ class MessageHandlerRuntimeHintsRegistrarTest {
         testReflectionMethod(SomeProjectionWithoutGroupAnnotation.class, "on");
         testReflectionMethod(SingleAggregateChild.class, "handle");
         testReflectionMethod(SomeAggregateChild.class, "handle");
+    }
+
+    @Test
+    void handlerInterceptorsHaveReflectiveHints() {
+        testReflectionMethod(SomeAggregate.class, "intercept");
+        testReflectionMethod(SomeAggregate.class, "exceptionHandler");
+        testReflectionMethod(SingleAggregateChild.class, "intercept");
+    }
+
+    @Test
+    void childEntitiesHaveReflectiveHints() {
+        testReflectionMethod(SomeAggregateChild.class, "handle");
+        testReflectionMethod(SingleAggregateChild.class, "intercept");
+        testReflectionMethod(SingleAggregateChild.class, "handle");
+        testForConstructor(ForwardMatchingInstances.class);
+        testForConstructor(ForwardToAll.class);
     }
 
     private void addClassToBeanFactory(Class<?> clazz) {


### PR DESCRIPTION
A few reflection hints were missing.
Most notably:
 - handlers with custom parameters were not registered and could not be invoked at runtime.
 - AggregateMember could not be used because the ForwardingMode could not be constructed at runtime